### PR TITLE
JWT (shopper token)

### DIFF
--- a/lib/lightrail_client.rb
+++ b/lib/lightrail_client.rb
@@ -2,6 +2,8 @@ require "faraday"
 require "openssl"
 require "json"
 require "securerandom"
+require "jwt"
+require "base64"
 
 require "lightrail_client/version"
 
@@ -9,6 +11,7 @@ require "lightrail_client/constants"
 require "lightrail_client/errors"
 require "lightrail_client/validator"
 require "lightrail_client/connection"
+require "lightrail_client/token_factory"
 
 require "lightrail_client/lightrail_object"
 require "lightrail_client/ping"
@@ -19,7 +22,7 @@ require "lightrail_client/contact"
 
 module Lightrail
   class << self
-    attr_accessor :api_base, :api_key
+    attr_accessor :api_base, :api_key, :client_secret
   end
   @api_base = 'https://api.lightrail.com/v1'
 end

--- a/lib/lightrail_client/token_factory.rb
+++ b/lib/lightrail_client/token_factory.rb
@@ -1,0 +1,35 @@
+module Lightrail
+  class TokenFactory
+    def self.generate (shopper_id, validity_in_seconds=nil)
+      raise Lightrail::BadParameterError.new("Lightrail::api_key is not set") unless Lightrail::api_key
+      raise Lightrail::BadParameterError.new("Lightrail::client_secret is not set") unless Lightrail::client_secret
+
+      payload = Lightrail::api_key.split('.')
+      payload = JSON.parse(Base64.decode64(payload[1]))
+      uid = payload['g']['gui']
+      g_claim = {
+          gui: uid
+      }
+
+      issued_at = Time.now.to_i
+
+      payload = {
+          shopperId: shopper_id,
+          iat: issued_at,
+          g: g_claim
+      }
+
+      if validity_in_seconds
+        expiry_time = issued_at + validity_in_seconds
+        payload[:exp] = expiry_time
+      end
+
+      token = [
+          {'data' => payload},
+          {'alg' => 'HS256'}
+      ]
+
+      JWT.encode(token, Lightrail::client_secret, 'HS256')
+    end
+  end
+end

--- a/lib/lightrail_client/version.rb
+++ b/lib/lightrail_client/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lightrail_client.gemspec
+++ b/lightrail_client.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faraday", "~>0.12"
   spec.add_runtime_dependency "json", "~>1.7"
   spec.add_runtime_dependency "openssl", "~>2.0"
+  spec.add_runtime_dependency "jwt", "~>2.1"
 end

--- a/spec/token_factory_spec.rb
+++ b/spec/token_factory_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe Lightrail::TokenFactory do
+  subject(:factory) {Lightrail::TokenFactory}
+
+  let(:example_api_key) {'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnIjp7Imd1aSI6InVzZXItZWI2NDYwYWZhNWIwNDQxYmFjYmI0MTI5MGZhZjAxNDctVEVTVCIsImdtaSI6InVzZXItZWI2NDYwYWZhNWIwNDQxYmFjYmI0MTI5MGZhZjAxNDctVEVTVCJ9LCJpYXQiOiIyMDE3LTA3LTA1VDIxOjM4OjQ5LjEzMSswMDAwIiwibmFtZSI6IkpvaG4gRG9lIn0.bhMlwrU4ZoMNRQB47-Twx2Eev7LpBG4d4Sc6Gmxq0oo'}
+  let(:example_client_secret) {'secret'}
+  let(:example_shopper_id) {'this-is-a-shopper-id'}
+
+
+  describe ".generate" do
+    before(:each) do
+      allow(Lightrail).to receive(:api_key).and_return(example_api_key)
+      allow(Lightrail).to receive(:client_secret).and_return(example_client_secret)
+    end
+
+    it "generates a JWT with the supplied shopper_id" do
+      token = factory.generate(example_shopper_id)
+      decoded = JWT.decode(token, example_client_secret, true, {algorithm: 'HS256'})
+
+      expect(decoded[0][0]['data']['shopperId']).to eq(example_shopper_id)
+    end
+
+    it "correctly applies the specified validity period" do
+      token = factory.generate(example_shopper_id, 12)
+      decoded = JWT.decode(token, example_client_secret, true, {algorithm: 'HS256'})
+
+      expect(decoded[0][0]['data']['exp']).to eq(decoded[0][0]['data']['iat'] + 12)
+    end
+  end
+end


### PR DESCRIPTION
Adds a 'token factory' to generate shopper-specific tokens. Used for turnkey integrations. 