### PR TITLE
Simulate transactions

### DIFF
--- a/lib/lightrail_client/card.rb
+++ b/lib/lightrail_client/card.rb
@@ -2,7 +2,12 @@ module Lightrail
   class Card < Lightrail::LightrailObject
 
     def self.charge(charge_params)
-      Lightrail::Transaction.charge_card(charge_params)
+      Lightrail::Transaction.charge_card(charge_params, false)
+    end
+
+    def self.simulate_charge(charge_params)
+      params_for_simulation = Lightrail::Validator.set_nsf_for_simulate!(charge_params)
+      Lightrail::Transaction.charge_card(params_for_simulation, true)
     end
 
     def self.fund(fund_params)

--- a/lib/lightrail_client/card.rb
+++ b/lib/lightrail_client/card.rb
@@ -14,20 +14,20 @@ module Lightrail
       Lightrail::Transaction.fund_card(fund_params)
     end
 
-    def self.get_balance_details(card_id)
-      response = Lightrail::Connection.make_get_request_and_parse_response("cards/#{card_id}/balance")
-      response['balance']
-    end
-
-    def self.get_total_balance(card_id)
-      balance_details = self.get_balance_details(card_id)
-      total = balance_details['principal']['currentValue']
-      balance_details['attached'].reduce(total) do |sum, valueStore|
-        if valueStore['state'] == "ACTIVE"
-          total += valueStore['currentValue']
+    def self.get_maximum_value(card_id)
+      card_details = self.get_details(card_id)
+      maximum_value = 0
+      card_details['valueStores'].each do |valueStore|
+        if valueStore['state'] == 'ACTIVE'
+          maximum_value += valueStore['value']
         end
       end
-      total
+      maximum_value
+    end
+
+    def self.get_details(card_id)
+      response = Lightrail::Connection.make_get_request_and_parse_response("cards/#{card_id}/details")
+      response['details']
     end
 
   end

--- a/lib/lightrail_client/code.rb
+++ b/lib/lightrail_client/code.rb
@@ -10,20 +10,20 @@ module Lightrail
       Lightrail::Transaction.charge_code(params_for_simulation, true)
     end
 
-    def self.get_balance_details(code)
-      response = Lightrail::Connection.make_get_request_and_parse_response("codes/#{code}/balance/details")
-      response['balance']
-    end
-
-    def self.get_total_balance(code)
-      balance_details = self.get_balance_details(code)
-      total = balance_details['principal']['currentValue']
-      balance_details['attached'].reduce(total) do |sum, valueStore|
-        if valueStore['state'] == "ACTIVE"
-          total += valueStore['currentValue']
+    def self.get_maximum_value(code)
+      code_details = self.get_details(code)
+      maximum_value = 0
+      code_details['valueStores'].each do |valueStore|
+        if valueStore['state'] == 'ACTIVE'
+          maximum_value += valueStore['value']
         end
       end
-      total
+      maximum_value
+    end
+
+    def self.get_details(code)
+      response = Lightrail::Connection.make_get_request_and_parse_response("codes/#{code}/details")
+      response['details']
     end
 
   end

--- a/lib/lightrail_client/code.rb
+++ b/lib/lightrail_client/code.rb
@@ -2,7 +2,12 @@ module Lightrail
   class Code
 
     def self.charge(charge_params)
-      Lightrail::Transaction.charge_code(charge_params)
+      Lightrail::Transaction.charge_code(charge_params, false)
+    end
+
+    def self.simulate_charge(charge_params)
+      params_for_simulation = Lightrail::Validator.set_nsf_for_simulate!(charge_params)
+      Lightrail::Transaction.charge_code(params_for_simulation, true)
     end
 
     def self.get_balance_details(code)

--- a/lib/lightrail_client/contact.rb
+++ b/lib/lightrail_client/contact.rb
@@ -6,6 +6,11 @@ module Lightrail
       Lightrail::Card.charge(params_with_account_card_id)
     end
 
+    def self.simulate_account_charge(charge_params)
+      params_with_account_card_id = self.replace_contact_id_or_shopper_id_with_card_id(charge_params)
+      Lightrail::Card.simulate_charge(params_with_account_card_id)
+    end
+
     def self.fund_account(fund_params)
       params_with_account_card_id = self.replace_contact_id_or_shopper_id_with_card_id(fund_params)
       Lightrail::Card.fund(params_with_account_card_id)

--- a/lib/lightrail_client/contact.rb
+++ b/lib/lightrail_client/contact.rb
@@ -16,14 +16,14 @@ module Lightrail
       Lightrail::Card.fund(params_with_account_card_id)
     end
 
-    def self.get_account_balance_details(balance_check_params)
-      params_with_account_card_id = self.replace_contact_id_or_shopper_id_with_card_id(balance_check_params)
-      Lightrail::Card.get_balance_details(params_with_account_card_id[:card_id])
+    def self.get_account_details(account_details_params)
+      params_with_account_card_id = self.replace_contact_id_or_shopper_id_with_card_id(account_details_params)
+      Lightrail::Card.get_details(params_with_account_card_id[:card_id])
     end
 
-    def self.get_account_total_balance(balance_check_params)
-      params_with_account_card_id = self.replace_contact_id_or_shopper_id_with_card_id(balance_check_params)
-      Lightrail::Card.get_total_balance(params_with_account_card_id[:card_id])
+    def self.get_maximum_account_value(max_account_value_params)
+      params_with_account_card_id = self.replace_contact_id_or_shopper_id_with_card_id(max_account_value_params)
+      Lightrail::Card.get_maximum_value(params_with_account_card_id[:card_id])
     end
 
     private

--- a/lib/lightrail_client/validator.rb
+++ b/lib/lightrail_client/validator.rb
@@ -51,6 +51,14 @@ module Lightrail
       raise Lightrail::LightrailArgumentError.new("Invalid fund_params for set_params_for_card_id_fund!: #{fund_params.inspect}")
     end
 
+    def self.set_nsf_for_simulate!(charge_params)
+      params_for_simulate = charge_params.clone
+      if (!params_for_simulate.key?([:nsf]) && !params_for_simulate.key?(['nsf']))
+        params_for_simulate[:nsf] = false
+      end
+      params_for_simulate
+    end
+
     def self.set_params_for_card_id_pending!(charge_params)
       begin
         validated_params = self.set_params_for_card_id_drawdown!(charge_params)

--- a/lib/lightrail_client/version.rb
+++ b/lib/lightrail_client/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe Lightrail::Card do
     end
   end
 
+  describe ".simulate_charge" do
+    it "simulates posting a charge to a card" do
+      expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions\/dryRun/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
+      card.simulate_charge(charge_params)
+    end
+
+    it "sets 'nsf' to 'false' by default" do
+      expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions\/dryRun/, hash_including(nsf: false)).and_return({"transaction" => {}})
+      card.simulate_charge(charge_params)
+    end
+  end
+
   describe ".fund" do
     it "funds a card" do
       expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -19,10 +19,12 @@ RSpec.describe Lightrail::Card do
       card_id: example_card_id,
   }}
 
-  let(:balance_response) {{
-      "principal" => {"currentValue" => 400, "state" => "ACTIVE", "programId" => "program-123456", "valueStoreId" => "value-123456"},
-      "attached" => [{"currentValue" => 50, "state" => "ACTIVE", "programId" => "program-789", "valueStoreId" => "value-2468"},
-                     {"currentValue" => 30, "state" => "EXPIRED", "programId" => "program-235", "valueStoreId" => "value-7643"}]
+  let(:details_response) {{
+      "valueStores" => [
+          {"valueStoreType" => "PRINCIPAL", "value" => 675, "state" => "ACTIVE"},
+          {"valueStoreType" => "ATTACHED", "value" => 1250, "state" => "ACTIVE"},
+          {"valueStoreType" => "ATTACHED", "value" => 3175, "state" => "EXPIRED"}
+      ]
   }}
 
   describe ".charge" do
@@ -51,19 +53,18 @@ RSpec.describe Lightrail::Card do
     end
   end
 
-  describe ".get_balance_details" do
-    it "gets the balance details by cardId" do
-      expect(lightrail_connection).to receive(:make_get_request_and_parse_response).with(/cards\/#{example_card_id}\/balance/).and_return({"balance" => {}})
-      card.get_balance_details(example_card_id)
+  describe ".get_details" do
+    it "gets the card details" do
+      expect(lightrail_connection).to receive(:make_get_request_and_parse_response).with(/cards\/#{example_card_id}\/details/).and_return({"details" => {}})
+      card.get_details(example_card_id)
     end
   end
 
-  describe ".get_total_balance" do
-    it "gets the total balance for a card" do
-      expect(card).to receive(:get_balance_details).with(example_card_id).and_return(balance_response)
-      balance = card.get_total_balance(example_card_id)
-      expect(balance).to be 450
+  describe ".get_maximum_value" do
+    it "tallies the value of all active value stores" do
+      expect(lightrail_connection).to receive(:make_get_request_and_parse_response).with(/cards\/#{example_card_id}\/details/).and_return({"details" => details_response})
+      max_val = card.get_maximum_value(example_card_id)
+      expect(max_val).to be 1925
     end
   end
-
 end

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -13,10 +13,12 @@ RSpec.describe Lightrail::Code do
       code: example_code,
   }}
 
-  let(:balance_response) {{
-      "principal" => {"currentValue" => 400, "state" => "ACTIVE", "programId" => "program-123456", "valueStoreId" => "value-123456"},
-      "attached" => [{"currentValue" => 50, "state" => "ACTIVE", "programId" => "program-789", "valueStoreId" => "value-2468"},
-                     {"currentValue" => 30, "state" => "EXPIRED", "programId" => "program-235", "valueStoreId" => "value-7643"}]
+  let(:details_response) {{
+      "valueStores" => [
+          {"valueStoreType" => "PRINCIPAL", "value" => 675, "state" => "ACTIVE"},
+          {"valueStoreType" => "ATTACHED", "value" => 1250, "state" => "ACTIVE"},
+          {"valueStoreType" => "ATTACHED", "value" => 3175, "state" => "EXPIRED"}
+      ]
   }}
 
   describe ".charge" do
@@ -38,18 +40,18 @@ RSpec.describe Lightrail::Code do
     end
   end
 
-  describe ".get_balance_details" do
-    it "gets the balance details by cardId" do
-      expect(lightrail_connection).to receive(:make_get_request_and_parse_response).with(/codes\/#{example_code}\/balance/).and_return({"balance" => {}})
-      code.get_balance_details(example_code)
+  describe ".get_details" do
+    it "gets the code details" do
+      expect(lightrail_connection).to receive(:make_get_request_and_parse_response).with(/codes\/#{example_code}\/details/).and_return({"details" => {}})
+      code.get_details(example_code)
     end
   end
 
-  describe ".get_total_balance" do
-    it "gets the total balance for a code" do
-      expect(code).to receive(:get_balance_details).with(example_code).and_return(balance_response)
-      balance = code.get_total_balance(example_code)
-      expect(balance).to be 450
+  describe ".get_maximum_value" do
+    it "tallies the value of all active value stores" do
+      expect(lightrail_connection).to receive(:make_get_request_and_parse_response).with(/codes\/#{example_code}\/details/).and_return({"details" => details_response})
+      max_val = code.get_maximum_value(example_code)
+      expect(max_val).to be 1925
     end
   end
 

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -26,6 +26,18 @@ RSpec.describe Lightrail::Code do
     end
   end
 
+  describe ".simulate_charge" do
+    it "simulates posting a charge to a code" do
+      expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{example_code}\/transactions\/dryRun/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
+      code.simulate_charge(charge_params)
+    end
+
+    it "sets 'nsf' to 'false' by default" do
+      expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{example_code}\/transactions\/dryRun/, hash_including(nsf: false)).and_return({"transaction" => {}})
+      code.simulate_charge(charge_params)
+    end
+  end
+
   describe ".get_balance_details" do
     it "gets the balance details by cardId" do
       expect(lightrail_connection).to receive(:make_get_request_and_parse_response).with(/codes\/#{example_code}\/balance/).and_return({"balance" => {}})

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -65,6 +65,40 @@ RSpec.describe Lightrail::Contact do
     end
   end
 
+  describe ".simulate_account_charge" do
+    it "simulates charging a contact's account given a shopperId & currency" do
+      expect(lightrail_connection)
+          .to receive(:make_get_request_and_parse_response)
+                  .with(/contacts\?userSuppliedId=#{example_shopper_id}/)
+                  .and_return({"contacts" => [{"contactId" => "this-is-a-contact-id"}]})
+      expect(lightrail_connection)
+          .to receive(:make_get_request_and_parse_response)
+                  .with(/cards\?contactId=#{example_contact_id}\&cardType=ACCOUNT_CARD\&currency=#{example_currency}/)
+                  .and_return({"cards" => [{"cardId" => "this-is-a-card-id"}]})
+      expect(lightrail_connection)
+          .to receive(:make_post_request_and_parse_response)
+                  .with(/cards\/#{example_card_id}\/transactions\/dryRun/, hash_including(:value, :currency))
+                  .and_return({"transaction" => {}})
+      contact.simulate_account_charge(charge_params_with_shopper_id)
+    end
+
+    it "simulates charging a contact's account given a shopperId & currency" do
+      expect(lightrail_connection)
+          .to receive(:make_get_request_and_parse_response)
+                  .with(/contacts\?userSuppliedId=#{example_shopper_id}/)
+                  .and_return({"contacts" => [{"contactId" => "this-is-a-contact-id"}]})
+      expect(lightrail_connection)
+          .to receive(:make_get_request_and_parse_response)
+                  .with(/cards\?contactId=#{example_contact_id}\&cardType=ACCOUNT_CARD\&currency=#{example_currency}/)
+                  .and_return({"cards" => [{"cardId" => "this-is-a-card-id"}]})
+      expect(lightrail_connection)
+          .to receive(:make_post_request_and_parse_response)
+                  .with(/cards\/#{example_card_id}\/transactions\/dryRun/, hash_including(:value, :currency))
+                  .and_return({"transaction" => {}})
+      contact.simulate_account_charge(charge_params_with_shopper_id)
+    end
+  end
+
   describe ".fund_account" do
     it "funds a contact's account given a contactId & currency" do
       expect(lightrail_connection)

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -129,20 +129,20 @@ RSpec.describe Lightrail::Contact do
     end
   end
 
-  describe ".get_account_balance_details" do
-    it "gets the balance details given a contactId & currency" do
+  describe ".get_account_details" do
+    it "gets the account card details given a contactId & currency" do
       expect(lightrail_connection)
           .to receive(:make_get_request_and_parse_response)
                   .with(/cards\?contactId=#{example_contact_id}\&cardType=ACCOUNT_CARD\&currency=#{example_currency}/)
                   .and_return({"cards" => [{"cardId" => "this-is-a-card-id"}]})
       expect(lightrail_connection)
           .to receive(:make_get_request_and_parse_response)
-                  .with(/cards\/#{example_card_id}\/balance/)
-                  .and_return({"balance" => {}})
-      contact.get_account_balance_details({contact_id: 'this-is-a-contact-id', currency: 'ABC'})
+                  .with(/cards\/#{example_card_id}\/details/)
+                  .and_return({"details" => {}})
+      contact.get_account_details({contact_id: 'this-is-a-contact-id', currency: 'ABC'})
     end
 
-    it "gets the balance details given a shopperId & currency" do
+    it "gets the account card details given a shopperId & currency" do
       expect(lightrail_connection)
           .to receive(:make_get_request_and_parse_response)
                   .with(/contacts\?userSuppliedId=#{example_shopper_id}/)
@@ -153,25 +153,25 @@ RSpec.describe Lightrail::Contact do
                   .and_return({"cards" => [{"cardId" => "this-is-a-card-id"}]})
       expect(lightrail_connection)
           .to receive(:make_get_request_and_parse_response)
-                  .with(/cards\/#{example_card_id}\/balance/)
-                  .and_return({"balance" => {}})
-      contact.get_account_balance_details({shopper_id: 'this-is-a-shopper-id', currency: 'ABC'})
+                  .with(/cards\/#{example_card_id}\/details/)
+                  .and_return({"details" => {}})
+      contact.get_account_details({shopper_id: 'this-is-a-shopper-id', currency: 'ABC'})
     end
   end
 
-  describe ".get_account_total_balance" do
-    it "gets the total balance given a contactId & currency" do
+  describe ".get_maximum_account_value" do
+    it "gets the maximum value of the account given a contactId & currency" do
       expect(lightrail_connection)
           .to receive(:make_get_request_and_parse_response)
                   .with(/cards\?contactId=#{example_contact_id}\&cardType=ACCOUNT_CARD\&currency=#{example_currency}/)
                   .and_return({"cards" => [{"cardId" => "this-is-a-card-id"}]})
       expect(Lightrail::Card)
-          .to receive(:get_total_balance)
+          .to receive(:get_maximum_value)
                   .with(example_card_id)
-      contact.get_account_total_balance({contact_id: 'this-is-a-contact-id', currency: 'ABC'})
+      contact.get_maximum_account_value({contact_id: 'this-is-a-contact-id', currency: 'ABC'})
     end
 
-    it "gets the total balance given a shopperId & currency" do
+    it "gets the maximum value of the account given a shopperId & currency" do
       expect(lightrail_connection)
           .to receive(:make_get_request_and_parse_response)
                   .with(/contacts\?userSuppliedId=#{example_shopper_id}/)
@@ -181,9 +181,9 @@ RSpec.describe Lightrail::Contact do
                   .with(/cards\?contactId=#{example_contact_id}\&cardType=ACCOUNT_CARD\&currency=#{example_currency}/)
                   .and_return({"cards" => [{"cardId" => "this-is-a-card-id"}]})
       expect(Lightrail::Card)
-          .to receive(:get_total_balance)
+          .to receive(:get_maximum_value)
                   .with(example_card_id)
-      contact.get_account_total_balance({shopper_id: 'this-is-a-shopper-id', currency: 'ABC'})
+      contact.get_maximum_account_value({shopper_id: 'this-is-a-shopper-id', currency: 'ABC'})
     end
   end
 

--- a/spec/transaction_spec.rb
+++ b/spec/transaction_spec.rb
@@ -48,13 +48,18 @@ RSpec.describe Lightrail::Transaction do
     context "when posting a drawdown transaction" do
       it "charges a code with minimum parameters" do
         expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{example_code}\/transactions/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
-        transaction.charge_code(code_charge_params)
+        transaction.charge_code(code_charge_params, false)
+      end
+
+      it "calls the dry run endpoint if 'simulate=true'" do
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{example_code}\/transactions\/dryRun/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
+        transaction.charge_code(code_charge_params, true)
       end
 
       it "charges a code first if both code and cardId are present" do
         code_charge_params[:card_id] = example_card_id
         expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{example_code}\/transactions/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
-        transaction.charge_code(code_charge_params)
+        transaction.charge_code(code_charge_params, false)
       end
     end
 
@@ -62,7 +67,7 @@ RSpec.describe Lightrail::Transaction do
       it "posts a pending transaction to a code" do
         code_charge_params[:pending] = true
         expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/codes\/#{example_code}\/transactions/, hash_including(:value, :currency, :userSuppliedId, pending: true)).and_return({"transaction" => {}})
-        transaction.charge_code(code_charge_params)
+        transaction.charge_code(code_charge_params, false)
       end
     end
 
@@ -72,7 +77,12 @@ RSpec.describe Lightrail::Transaction do
     context "when posting a drawdown transaction" do
       it "charges a card with minimum parameters" do
         expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
-        transaction.charge_card(card_id_charge_params)
+        transaction.charge_card(card_id_charge_params, false)
+      end
+
+      it "calls the dry run endpoint if 'simulate=true'" do
+        expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions\/dryRun/, hash_including(:value, :currency, :userSuppliedId)).and_return({"transaction" => {}})
+        transaction.charge_card(card_id_charge_params, true)
       end
     end
 
@@ -80,7 +90,7 @@ RSpec.describe Lightrail::Transaction do
       it "posts a pending transaction to a card_id" do
         card_id_charge_params[:pending] = true
         expect(lightrail_connection).to receive(:make_post_request_and_parse_response).with(/cards\/#{example_card_id}\/transactions/, hash_including(:value, :currency, :userSuppliedId, pending: true)).and_return({"transaction" => {}})
-        transaction.charge_card(card_id_charge_params)
+        transaction.charge_card(card_id_charge_params, false)
       end
     end
 


### PR DESCRIPTION
Simulate code/card/contact transactions by calling the '/dryRun' endpoint. This replaces the previous balance check logic with more up-to-date / best practices to perform transaction-specific balance checking, as well as a 'maximum value' check. 