### PR TITLE
JWT (shopper token) update

### DIFF
--- a/lib/lightrail_client.rb
+++ b/lib/lightrail_client.rb
@@ -22,7 +22,7 @@ require "lightrail_client/contact"
 
 module Lightrail
   class << self
-    attr_accessor :api_base, :api_key, :client_secret
+    attr_accessor :api_base, :api_key, :shared_secret
   end
   @api_base = 'https://api.lightrail.com/v1'
 end

--- a/lib/lightrail_client.rb
+++ b/lib/lightrail_client.rb
@@ -11,7 +11,7 @@ require "lightrail_client/constants"
 require "lightrail_client/errors"
 require "lightrail_client/validator"
 require "lightrail_client/connection"
-require "lightrail_client/token_factory"
+require "lightrail_client/shopper_token_factory"
 
 require "lightrail_client/lightrail_object"
 require "lightrail_client/ping"

--- a/lib/lightrail_client/shopper_token_factory.rb
+++ b/lib/lightrail_client/shopper_token_factory.rb
@@ -1,5 +1,5 @@
 module Lightrail
-  class TokenFactory
+  class ShopperTokenFactory
     def self.generate (contact, validity_in_seconds=nil)
       raise Lightrail::BadParameterError.new("Lightrail::api_key is not set") unless Lightrail::api_key
       raise Lightrail::BadParameterError.new("Lightrail::shared_secret is not set") unless Lightrail::shared_secret

--- a/lib/lightrail_client/token_factory.rb
+++ b/lib/lightrail_client/token_factory.rb
@@ -1,27 +1,38 @@
 module Lightrail
   class TokenFactory
-    def self.generate (shopper_id, validity_in_seconds=nil)
+    def self.generate (contact, validity_in_seconds=nil)
       raise Lightrail::BadParameterError.new("Lightrail::api_key is not set") unless Lightrail::api_key
       raise Lightrail::BadParameterError.new("Lightrail::shared_secret is not set") unless Lightrail::shared_secret
 
+      raise Lightrail::BadParameterError.new("Must provide a contact with one of shopper_id, contact_id or user_supplied_id to generate a shopper token") unless (Lightrail::Validator.has_valid_shopper_id?(contact) ||
+          Lightrail::Validator.has_valid_contact_id?(contact) ||
+          Lightrail::Validator.has_valid_user_supplied_id?(contact))
+
+      g = {}
+      if (Lightrail::Validator.has_valid_shopper_id?(contact))
+        g['shi'] = Lightrail::Validator.get_shopper_id(contact)
+      elsif (Lightrail::Validator.has_valid_contact_id?(contact))
+        g['coi'] = Lightrail::Validator.get_contact_id(contact)
+      elsif (Lightrail::Validator.has_valid_user_supplied_id?(contact))
+        g['cui'] = Lightrail::Validator.get_user_supplied_id(contact)
+      end
+
+
       payload = Lightrail::api_key.split('.')
       payload = JSON.parse(Base64.decode64(payload[1]))
-      uid = payload['g']['gui']
-      g_claim = {
-          gui: uid
-      }
 
-      issued_at = Time.now.to_i
+      g['gui'] = payload['g']['gui']
+      g['gmi'] = payload['g']['gmi']
 
+      iat = Time.now.to_i
       payload = {
-          shopperId: shopper_id,
-          iat: issued_at,
-          g: g_claim
+          g: g,
+          iat: iat,
+          iss: "MERCHANT"
       }
 
       if validity_in_seconds
-        expiry_time = issued_at + validity_in_seconds
-        payload[:exp] = expiry_time
+        payload['exp'] = iat + validity_in_seconds
       end
 
       token = [

--- a/lib/lightrail_client/token_factory.rb
+++ b/lib/lightrail_client/token_factory.rb
@@ -2,7 +2,7 @@ module Lightrail
   class TokenFactory
     def self.generate (shopper_id, validity_in_seconds=nil)
       raise Lightrail::BadParameterError.new("Lightrail::api_key is not set") unless Lightrail::api_key
-      raise Lightrail::BadParameterError.new("Lightrail::client_secret is not set") unless Lightrail::client_secret
+      raise Lightrail::BadParameterError.new("Lightrail::shared_secret is not set") unless Lightrail::shared_secret
 
       payload = Lightrail::api_key.split('.')
       payload = JSON.parse(Base64.decode64(payload[1]))
@@ -29,7 +29,7 @@ module Lightrail
           {'alg' => 'HS256'}
       ]
 
-      JWT.encode(token, Lightrail::client_secret, 'HS256')
+      JWT.encode(token, Lightrail::shared_secret, 'HS256')
     end
   end
 end

--- a/lib/lightrail_client/validator.rb
+++ b/lib/lightrail_client/validator.rb
@@ -203,6 +203,11 @@ module Lightrail
       shopperId && self.validate_shopper_id!(shopperId)
     end
 
+    def self.has_valid_user_supplied_id?(charge_params)
+      userSuppliedId = (charge_params.respond_to? :keys) ? self.get_user_supplied_id(charge_params) : false
+      userSuppliedId && self.validate_shopper_id!(userSuppliedId) # A contact's userSuppliedId is the same as their shopperId
+    end
+
     def self.has_valid_transaction_id?(charge_params)
       transactionId = (charge_params.respond_to? :keys) ? self.get_transaction_id(charge_params) : false
       transactionId && self.validate_transaction_id!(transactionId)
@@ -236,6 +241,11 @@ module Lightrail
 
     def self.get_code_or_card_id_key(charge_params)
       (charge_params.keys & Lightrail::Constants::LIGHTRAIL_PAYMENT_METHODS).first
+    end
+
+    def self.get_user_supplied_id(charge_params)
+      user_supplied_id_key = (charge_params.keys & Lightrail::Constants::LIGHTRAIL_USER_SUPPLIED_ID_KEYS).first
+      charge_params[user_supplied_id_key]
     end
 
     def self.get_or_create_user_supplied_id(charge_params)

--- a/lib/lightrail_client/version.rb
+++ b/lib/lightrail_client/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/shopper_token_factory_spec.rb
+++ b/spec/shopper_token_factory_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-RSpec.describe Lightrail::TokenFactory do
-  subject(:factory) {Lightrail::TokenFactory}
+RSpec.describe Lightrail::ShopperTokenFactory do
+  subject(:factory) {Lightrail::ShopperTokenFactory}
 
   let(:example_api_key) {'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnIjp7Imd1aSI6Imdvb2V5IiwiZ21pIjoiZ2VybWllIn19.XxOjDsluAw5_hdf5scrLk0UBn8VlhT-3zf5ZeIkEld8'}
   let(:example_shared_secret) {'secret'}

--- a/spec/token_factory_spec.rb
+++ b/spec/token_factory_spec.rb
@@ -4,26 +4,26 @@ RSpec.describe Lightrail::TokenFactory do
   subject(:factory) {Lightrail::TokenFactory}
 
   let(:example_api_key) {'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnIjp7Imd1aSI6InVzZXItZWI2NDYwYWZhNWIwNDQxYmFjYmI0MTI5MGZhZjAxNDctVEVTVCIsImdtaSI6InVzZXItZWI2NDYwYWZhNWIwNDQxYmFjYmI0MTI5MGZhZjAxNDctVEVTVCJ9LCJpYXQiOiIyMDE3LTA3LTA1VDIxOjM4OjQ5LjEzMSswMDAwIiwibmFtZSI6IkpvaG4gRG9lIn0.bhMlwrU4ZoMNRQB47-Twx2Eev7LpBG4d4Sc6Gmxq0oo'}
-  let(:example_client_secret) {'secret'}
+  let(:example_shared_secret) {'secret'}
   let(:example_shopper_id) {'this-is-a-shopper-id'}
 
 
   describe ".generate" do
     before(:each) do
       allow(Lightrail).to receive(:api_key).and_return(example_api_key)
-      allow(Lightrail).to receive(:client_secret).and_return(example_client_secret)
+      allow(Lightrail).to receive(:shared_secret).and_return(example_shared_secret)
     end
 
     it "generates a JWT with the supplied shopper_id" do
       token = factory.generate(example_shopper_id)
-      decoded = JWT.decode(token, example_client_secret, true, {algorithm: 'HS256'})
+      decoded = JWT.decode(token, example_shared_secret, true, {algorithm: 'HS256'})
 
       expect(decoded[0][0]['data']['shopperId']).to eq(example_shopper_id)
     end
 
     it "correctly applies the specified validity period" do
       token = factory.generate(example_shopper_id, 12)
-      decoded = JWT.decode(token, example_client_secret, true, {algorithm: 'HS256'})
+      decoded = JWT.decode(token, example_shared_secret, true, {algorithm: 'HS256'})
 
       expect(decoded[0][0]['data']['exp']).to eq(decoded[0][0]['data']['iat'] + 12)
     end


### PR DESCRIPTION
Updates shopper token generator to comply with updated API requirements: 
- Token generator now takes a **hash** including any of `contact_id`, `shopper_id`, or contact `user_supplied_id` to identify a contact. 
- Also adds `iss: "MERCHANT"`

The secret value is now referred to as the `shared_secret` rather than the `client_secret` for consistency with other client libraries. 