### PR TITLE
Create contact for new account

### DIFF
--- a/lib/lightrail_client/account.rb
+++ b/lib/lightrail_client/account.rb
@@ -17,10 +17,6 @@ module Lightrail
         contact = Lightrail::Contact.retrieve_or_create_by_shopper_id(shopper_id)
       end
 
-      if !contact
-        raise Lightrail::LightrailArgumentError.new("Account creation error: could not get or create the specified contact. Params: #{account_params}")
-      end
-
       # If the contact already has an account in that currency, return it
       account_card = Lightrail::Account.retrieve({contact_id: contact['contactId'], currency: account_params[:currency]})
       return account_card['cardId'] if account_card

--- a/lib/lightrail_client/account.rb
+++ b/lib/lightrail_client/account.rb
@@ -10,7 +10,7 @@ module Lightrail
       if contact_id
         contact = Lightrail::Contact.retrieve_by_contact_id(contact_id)
         if shopper_id && (contact['userSuppliedId'] != shopper_id)
-          raise Lightrail::LightrailArgumentError.new("Account creation error: you've specified two different contacts to attach this account to.")
+          raise Lightrail::LightrailArgumentError.new("Account creation error: you've specified both a contactId and a shopperId for this account, but the contact with that contactId has a different shopperId.")
         end
 
       elsif shopper_id

--- a/lib/lightrail_client/contact.rb
+++ b/lib/lightrail_client/contact.rb
@@ -20,6 +20,14 @@ module Lightrail
 
     # Utility methods
 
+    def self.retrieve_or_create_by_shopper_id(shopper_id)
+      contact = self.retrieve_by_shopper_id(shopper_id)
+      if !contact
+        contact = self.create({shopper_id: shopper_id})
+      end
+      contact
+    end
+
     def self.get_contact_id_from_id_or_shopper_id(charge_params)
       if Lightrail::Validator.has_valid_contact_id?(charge_params)
         return Lightrail::Validator.get_contact_id(charge_params)

--- a/lib/lightrail_client/validator.rb
+++ b/lib/lightrail_client/validator.rb
@@ -69,7 +69,7 @@ module Lightrail
       begin
         return validated_params if ((validated_params.is_a? Hash) &&
             self.set_userSuppliedId_from_existing!(validated_params, validated_params) &&
-            self.set_contactId_from_contact_or_shopper_id!(validated_params, validated_params) &&
+            (self.has_valid_shopper_id?(validated_params) || self.has_valid_contact_id?(validated_params)) &&
             self.validate_currency!(validated_params[:currency]) &&
             Lightrail::Account.set_account_card_type(validated_params))
       rescue Lightrail::LightrailArgumentError

--- a/lib/lightrail_client/version.rb
+++ b/lib/lightrail_client/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end

--- a/spec/contact_spec.rb
+++ b/spec/contact_spec.rb
@@ -108,6 +108,31 @@ RSpec.describe Lightrail::Contact do
         expect(contact_id_result).to be(nil)
       end
     end
+
+    describe ".retrieve_or_create_by_shopper_id" do
+      it "returns existing contact if there is one" do
+        expect(lightrail_connection)
+            .to receive(:make_get_request_and_parse_response)
+                    .with(/contacts\?userSuppliedId=#{example_shopper_id}/)
+                    .and_return({"contacts" => [{"userSuppliedId" => "this-is-a-shopper-id"}]})
+        contact_result = contact.retrieve_or_create_by_shopper_id(example_shopper_id)
+        expect(contact_result['userSuppliedId']).to eq(example_shopper_id)
+      end
+
+      it "creates new contact if one does not exist" do
+        expect(lightrail_connection)
+            .to receive(:make_get_request_and_parse_response)
+                    .with(/contacts\?userSuppliedId=this-is-a-shopper-id/)
+                    .and_return({"contacts" => []})
+        expect(lightrail_connection)
+            .to receive(:make_post_request_and_parse_response)
+                    .with(/contacts/, hash_including({userSuppliedId: example_shopper_id}))
+                    .and_return({"contact" => {"userSuppliedId" => example_shopper_id}})
+
+        contact_result = contact.retrieve_or_create_by_shopper_id(example_shopper_id)
+        expect(contact_result['userSuppliedId']).to be(example_shopper_id)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Account creation updated such that:
- It first checks to see if the specified contact exists
- If it doesn't exist and the shopperId was provided, create it (otherwise throw error: can't create a contact by contactId even if provided)
- Then check to see whether the contact already has an account in that currency; return it if so
- ...And then create a new account