### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lightrail Client for Ruby
 
-Lightrail is a modern platform for digital account credits, gift cards, promotions, and points (to learn more, visit [Lightrail](https://www.lightrail.com/)). This is a basic library for developers to easily connect with the Lightrail API using Ruby. If you are looking for specific use cases or other languages, check out the complete list of all [Lightrail libraries and integrations](https://github.com/Giftbit/Lightrail-API-Docs/blob/master/docs/client-libraries.md).
+Lightrail is a modern platform for digital account credits, gift cards, promotions, and points (to learn more, visit [Lightrail](https://www.lightrail.com/)). This is a basic library for developers to easily connect with the Lightrail API using Ruby. If you are looking for specific use cases or other languages, check out the complete list of all [Lightrail libraries](https://www.lightrail.com/docs/#client-libraries/client-libraries).
 
 ## Features
 
@@ -9,11 +9,11 @@ The following features are supported in this version:
 - Account Credits: create, retrieve, charge, refund, balance-check, and fund.
 - Gift Cards: charge, refund, balance-check, and fund.
 
-Note that the Lightrail API supports many other features and we are working on covering them in this gem. For a complete list of Lightrail API features check out the [Lightrail API documentation](https://www.lightrail.com/docs/).
+Note that the Lightrail API supports many other features and we are working on covering them in this gem. For a complete list of Lightrail API features check out the [Lightrail API documentation](https://www.lightrail.com/docs/reference/).
 
 ## Related Projects
 
-Check out the full list of [Lightrail client libraries and integrations](https://github.com/Giftbit/Lightrail-API-Docs/blob/master/docs/client-libraries.md). 
+Check out the full list of [Lightrail client libraries](https://www.lightrail.com/docs/#client-libraries/client-libraries). 
 
 ## Usage
 
@@ -27,14 +27,14 @@ Lightrail.api_key = "<your lightrail API key>"
 
 ### Use Case: Account Credits Powered by Lightrail
 
-For a quick demonstration of implementing account credits using this library, see our [Accounts Quickstart](https://github.com/Giftbit/Lightrail-API-Docs/blob/master/docs/quickstart/accounts.md). 
+For a quick demonstration of implementing account credits using this library, see our [Accounts Quickstart](https://www.lightrail.com/docs/#accounts/accounts). 
 
 
 ### Use Case: Gift Cards
 
 **Looking for Lightrail's Drop-In Gift Card Solution?** 
 
-Check out our [Drop-in Gift Card documentation](https://github.com/Giftbit/Lightrail-API-Docs/blob/master/docs/quickstart/drop-in-gift-cards.md#drop-in-gift-cards) to get started.
+Check out our [Drop-in Gift Card documentation](https://www.lightrail.com/docs/#drop-in-gift-cards/drop-in-gift-cards) to get started.
 
 **Prefer to build it yourself?**
 
@@ -167,7 +167,7 @@ gift_charge = Lightrail::Code.charge({
     }
 ```
 
-**A note on idempotency:** All calls to create or act on transactions (refund, void, capture) can optionally take a `userSuppliedId` parameter. The `userSuppliedId` is a client-side identifier (unique string) which is used to ensure idempotency (for more details, see the  [API documentation](https://www.lightrail.com/docs/)). If you do not provide a `userSuppliedId`, the gem will create one for you for any calls that require one.
+**A note on idempotency:** All calls to create or act on transactions (refund, void, capture) can optionally take a `userSuppliedId` parameter. The `userSuppliedId` is a client-side identifier (unique string) which is used to ensure idempotency (for more details, see the  [API documentation](https://www.lightrail.com/docs/reference/)). If you do not provide a `userSuppliedId`, the gem will create one for you for any calls that require one.
 
 ```ruby
 gift_charge = Lightrail::Code.charge({
@@ -180,7 +180,7 @@ gift_charge = Lightrail::Code.charge({
 
 Note that Lightrail does not support currency exchange and the currency provided to these methods must match the currency of the gift card.
 
-For more details on the parameters that you can pass in for a charge request and the response that you will get back, see the [API documentation](https://www.lightrail.com/docs/).
+For more details on the parameters that you can pass in for a charge request and the response that you will get back, see the [API documentation](https://www.lightrail.com/docs/reference/).
 
 #### Authorize-Capture Flow
 
@@ -246,7 +246,7 @@ Lightrail::Transaction.refund(gift_charge)
     }
 ```
 
-Note that this does not necessarily mean that the refunded amount is available for a re-charge. In the edge case where the funds for the original charge came from a promotion which has now expired, refunding will return those funds back to the now-expired value store and therefore the value will not be available for re-charge. To learn more about using value stores for temporary promotions, see the [Lightrail API docs](https://github.com/Giftbit/Lightrail-API-Docs/blob/master/use-cases/promotions.md).
+Note that this does not necessarily mean that the refunded amount is available for a re-charge. In the edge case where the funds for the original charge came from a promotion which has now expired, refunding will return those funds back to the now-expired value store and therefore the value will not be available for re-charge. To learn more about using value stores for temporary promotions, see the [Promotions Quickstart](https://www.lightrail.com/docs/#promotions/promotions).
 
 #### Funding a Gift Card
 

--- a/lib/lightrail_client/account.rb
+++ b/lib/lightrail_client/account.rb
@@ -4,8 +4,8 @@ module Lightrail
       validated_params = Lightrail::Validator.set_params_for_account_create!(account_params)
 
       # Make sure contact exists first
-      contact_id = Lightrail::Validator.get_contact_id(account_params)
-      shopper_id = Lightrail::Validator.get_shopper_id(account_params)
+      contact_id = Lightrail::Validator.get_contact_id(validated_params)
+      shopper_id = Lightrail::Validator.get_shopper_id(validated_params)
 
       if contact_id
         contact = Lightrail::Contact.retrieve_by_contact_id(contact_id)
@@ -18,7 +18,7 @@ module Lightrail
       end
 
       # If the contact already has an account in that currency, return it
-      account_card = Lightrail::Account.retrieve({contact_id: contact['contactId'], currency: account_params[:currency]})
+      account_card = Lightrail::Account.retrieve({contact_id: contact['contactId'], currency: validated_params[:currency]})
       return account_card['cardId'] if account_card
 
       params_with_contact_id = validated_params.clone

--- a/lib/lightrail_client/validator.rb
+++ b/lib/lightrail_client/validator.rb
@@ -166,7 +166,7 @@ module Lightrail
     end
 
     def self.validate_shopper_id! (shopper_id)
-      return true if ((shopper_id.is_a? String) && ((/\A[A-Z0-9\-]+\z/i =~ shopper_id).is_a? Integer))
+      return true if ((shopper_id.is_a? String) && ((/\A[A-Z0-9\-\@\.]+\z/i =~ shopper_id).is_a? Integer))
       raise Lightrail::LightrailArgumentError.new("Invalid shopper_id: #{shopper_id.inspect}")
     end
 

--- a/lib/lightrail_client/version.rb
+++ b/lib/lightrail_client/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/spec/validator_spec.rb
+++ b/spec/validator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Lightrail::Validator do
   let(:example_transaction_id) {'this-is-a-transaction-id'}
   let(:example_contact_id) {'this-is-a-contact-id'}
   let(:example_shopper_id) {'this-is-a-shopper-id'}
+  let(:example_email) {'first.last@example.com'}
 
   let(:code_charge_params) {{
       amount: 1,
@@ -197,6 +198,10 @@ RSpec.describe Lightrail::Validator do
     describe ".validate_shopper_id!" do
       it "returns true for a string of the right format" do
         expect(validator.validate_shopper_id! (example_shopper_id)).to be true
+      end
+
+      it "returns true for a standard email address" do
+        expect(validator.validate_shopper_id! (example_email)).to be true
       end
 
       it "raises LightrailArgumentError for any other type" do


### PR DESCRIPTION
Fixes Validator so that it accepts standard email addresses for `shopper_id`. This aligns with what the documentation recommends. 
Also updates links in readme.md to point to updated documentation. 