### PR TITLE
Generic code options

### DIFF
--- a/lib/lightrail_client/resources/contacts.rb
+++ b/lib/lightrail_client/resources/contacts.rb
@@ -23,6 +23,11 @@ module Lightrail
       Lightrail::Connection.post("#{Lightrail.api_base}/contacts/#{CGI::escape(id)}/values/attach", params)
     end
 
+    def self.detach_value_from_contact(id, params)
+      Lightrail::Validators.validate_id(id, "contact_id")
+      Lightrail::Connection.post("#{Lightrail.api_base}/contacts/#{CGI::escape(id)}/values/detach", params)
+    end
+
     def self.list_contact_values(id, query_params = {})
       Lightrail::Connection.get("#{Lightrail.api_base}/contacts/#{CGI::escape(id)}/values", query_params)
     end

--- a/lib/lightrail_client/resources/values.rb
+++ b/lib/lightrail_client/resources/values.rb
@@ -22,10 +22,5 @@ module Lightrail
       Lightrail::Validators.validate_id(id)
       Lightrail::Connection.post("#{Lightrail.api_base}/values/#{CGI::escape(id)}/changeCode", params)
     end
-
-    def self.delete(id)
-      Lightrail::Validators.validate_id(id)
-      Lightrail::Connection.delete("#{Lightrail.api_base}/values/#{CGI::escape(id)}")
-    end
   end
 end

--- a/lib/lightrail_client/version.rb
+++ b/lib/lightrail_client/version.rb
@@ -1,3 +1,3 @@
 module Lightrail
-  VERSION = "2.0.0"
+  VERSION = "3.0.0"
 end

--- a/spec/resources/contacts_spec.rb
+++ b/spec/resources/contacts_spec.rb
@@ -78,14 +78,21 @@ RSpec.describe Lightrail::Contacts do
       expect(attach.body["contactId"]).to eq(contact_id)
     end
 
-    it "can attach a value to a contact by code" do
+    it "can attach a generic code to a contact" do
       # create the value
       code = SecureRandom.alphanumeric.to_s
+      genericValueId = SecureRandom.uuid
       create = Lightrail::Values.create(
           {
-              id: SecureRandom.uuid,
+              id: genericValueId,
               currency: "USD",
-              balance: 10,
+              isGenericCode: true,
+              genericCodeOptions: {
+                  perContact: {
+                      balance: 100,
+                      usesRemaining: 1
+                  }
+              },
               code: code
           })
       expect(create.status).to eq(201)
@@ -94,6 +101,7 @@ RSpec.describe Lightrail::Contacts do
       attach = contacts.attach_value_to_contact(contact_id, {code: code})
       expect(attach.status).to eq(200)
       expect(attach.body["contactId"]).to eq(contact_id)
+      expect(attach.body["attachedFromValueId"]).to eq(genericValueId)
     end
 
     it "can list contact values - expect 2 attached" do

--- a/spec/resources/contacts_spec.rb
+++ b/spec/resources/contacts_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Lightrail::Contacts do
       expect(update.body["firstName"]).to eq("who_is_alice")
     end
 
-    it "can attach a value to a contact by valueId" do
+    it "can attach & detach a value to a contact by valueId" do
       # create the value
       value_id = SecureRandom.uuid
       create = Lightrail::Values.create(
@@ -76,6 +76,11 @@ RSpec.describe Lightrail::Contacts do
       attach = contacts.attach_value_to_contact(contact_id, {valueId: value_id})
       expect(attach.status).to eq(200)
       expect(attach.body["contactId"]).to eq(contact_id)
+
+      # detach
+      detach = contacts.detach_value_from_contact(contact_id, {valueId: value_id})
+      expect(detach.status).to eq(200)
+      expect(detach.body["contactId"]).to be_nil
     end
 
     it "can attach a generic code to a contact" do
@@ -104,10 +109,10 @@ RSpec.describe Lightrail::Contacts do
       expect(attach.body["attachedFromValueId"]).to eq(genericValueId)
     end
 
-    it "can list contact values - expect 2 attached" do
+    it "can list contact values - expect 1 attached" do
       list = contacts.list_contact_values(contact_id)
       expect(list.status).to eq(200)
-      expect(list.body.length).to eq(2)
+      expect(list.body.length).to eq(1)
     end
 
     it "can delete a Contact" do

--- a/spec/resources/values_spec.rb
+++ b/spec/resources/values_spec.rb
@@ -142,15 +142,6 @@ RSpec.describe Lightrail::Values do
           expect(error.message).to_not be_nil
         end
       end
-
-      it "can't delete a Value that doesn't exist - results in error" do
-        expect {
-          values.delete("NOT_A_VALID_ID")
-        }.to raise_error do |error|
-          expect(error).to be_a(Lightrail::LightrailError)
-          expect(error.status).to eq(404)
-        end
-      end
     end
 
     # Extra test coverage

--- a/spec/resources/values_spec.rb
+++ b/spec/resources/values_spec.rb
@@ -93,21 +93,6 @@ RSpec.describe Lightrail::Values do
       expect(display_code.body["code"].length).to eq(11)
     end
 
-    it "can delete a Value" do
-      # delete only works for Value
-      value_id_to_delete = SecureRandom.uuid
-      create = values.create(
-          {
-              id: value_id_to_delete,
-              currency: "USD",
-              balance: 0
-          })
-      expect(create.status).to eq(201)
-
-      delete = values.delete(value_id_to_delete)
-      expect(delete.status).to eq(200)
-    end
-
     describe "error cases an exception handling" do
       it "can't create a Value without an id - test basic error handling" do
         expect {values.create({currency: "USD"})
@@ -189,6 +174,25 @@ RSpec.describe Lightrail::Values do
           })
       expect(create.body["currency"]).to eq("USD")
       expect(create.body["balance"]).to eq(15)
+    end
+
+    it "can create a generic code" do
+      create = values.create({
+                                 id: SecureRandom.uuid,
+                                 currency: "USD",
+                                 code: SecureRandom.alphanumeric.to_s,
+                                 isGenericCode: true,
+                                 discount: true,
+                                 pretax: true,
+                                 genericCodeOptions: {
+                                     perContact: {
+                                         balance: 500,
+                                         usesRemaining: 1
+                                     }
+                                 }
+                             })
+      expect(create.body["genericCodeOptions"]["perContact"]["balance"]).to eq(500)
+      expect(create.body["genericCodeOptions"]["perContact"]["usesRemaining"]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
# Changes
- Property genericCodeOptions is supported by the library based on how it is setup. 
- Adds test for `genericCodeOptions`. 
- Checked for any missing functions in library. 
  - Added detach. 
  - Removed Values delete. It is no longer supported by the API. 
- Major version increase since removing values.delete is a breaking change.
